### PR TITLE
Fix oc-login version

### DIFF
--- a/.github/workflows/staging-deploy.yaml
+++ b/.github/workflows/staging-deploy.yaml
@@ -41,7 +41,7 @@ jobs:
           sudo mv oc /usr/local/bin/
 
       - name: Log in to OpenShift
-        uses: redhat-actions/oc-login@v2
+        uses: redhat-actions/oc-login@v1
         with:
           openshift_server_url: ${{ env.OPENSHIFT_SERVER }}
           openshift_token: ${{ env.OPENSHIFT_TOKEN }}


### PR DESCRIPTION
According to [https://github.com/redhat-actions/oc-login](https://github.com/redhat-actions/oc-login) version 1 is the newest one, meaning there is no version 2.