### PR TITLE
Openshift Microsoft API Key

### DIFF
--- a/backend/utils/config.js
+++ b/backend/utils/config.js
@@ -5,4 +5,8 @@ export const MONGO_DB_URL =
     ? process.env.TEST_MONGO_DB_URL
     : process.env.MONGO_DB_URL;
 
-export const MS_API_KEY = process.env.MS_API_KEY;
+export const TENANT_ID = process.env.TENANT_ID;
+
+export const CLIENT_ID = process.env.CLIENT_ID;
+
+export const CLIENT_SECRET = process.env.CLIENT_SECRET;

--- a/manifests/backend-deployment.yaml
+++ b/manifests/backend-deployment.yaml
@@ -29,8 +29,18 @@ spec:
                 configMapKeyRef:
                   name: infopiste-config
                   key: MONGO_DB_URL
-            - name: MS_API_KEY
+            - name: TENANT_ID
               valueFrom:
                 configMapKeyRef:
                   name: infopiste-config
-                  key: MS_API_KEY
+                  key: TENANT_ID
+            - name: CLIENT_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: infopiste-config
+                  key: CLIENT_ID
+            - name: CLIENT_SECRET
+              valueFrom:
+                configMapKeyRef:
+                  name: infopiste-config
+                  key: CLIENT_SECRET


### PR DESCRIPTION
The `MS_API_KEY` environment variable has been added to `backend-deployment.yaml`, which is then injected into the container on the staging server. The value is received from a `configmap.yaml` within the same directory, which should look like this:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: infopiste-config
data:
  MS_API_KEY: key_here
  ```
The `MONGO_DB_URL` is also received similarly, from the same file.
The file has been added to .gitignore so that the key and other sensitive information doesn't leak.
The environment variable is also defined in `config.js`, so that it can be used in the application.
Resolves #22 