### PR TITLE
Add warning regarding env file

### DIFF
--- a/documentation/backend.md
+++ b/documentation/backend.md
@@ -71,6 +71,9 @@ In Docker:
 
 ## Docker
 
+> [!CAUTION]  
+> Do not put API-keys in `.sample.env`! Copy the file, name the copy `.env` and fill the values there.
+
 The backend can also be run with Docker. The [docker-compose.yaml](../docker-compose.yaml) present at the root of the project builds the backend using the backend's Dockerfile, and then maps it to port 1234. To run the file, execute the following command:
 
 ```bash


### PR DESCRIPTION
Warning just to make sure that nobody accidentally commits secrets since `.sample.env` is not in `.gitignore` .