### PR TITLE
Remove dot from test

### DIFF
--- a/frontend/tests/integration/App.navigation.test.jsx
+++ b/frontend/tests/integration/App.navigation.test.jsx
@@ -34,6 +34,6 @@ describe('App - Navigation and URL params', () => {
     const bulletinBoardButton = await screen.findByText('Bulletin Board');
     await user.click(bulletinBoardButton);
 
-    expect(await screen.findByText('No PDFs were found.')).toBeInTheDocument();
+    expect(await screen.findByText('No PDFs were found')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
One of the tests (specifically `'bulletin board can be accessed'`) under `App.navigation.test.jsx` broke because the frontend was refactored to say "No PDFs were found" without a dot, which the test attempted to still find.