### PR TITLE
fix proxy headers for rate limit

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -18,6 +18,8 @@ app.use(express.json());
 app.use(apiLimiter);
 app.use(requestLogger);
 
+app.set('trust proxy', 1);
+
 app.use('/api/rooms', roomsRouter);
 app.use('/api/reservations', reservationsRouter);
 app.use('/api/forms', formsRouter);

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,5 @@
 services:
   backend:
-    image: ohtuinfopiste/infopiste-backend:staging
     build:
       context: ./backend
       dockerfile: Dockerfile
@@ -16,7 +15,6 @@ services:
       - mongo
       - redis
   frontend:
-    image: ohtuinfopiste/infopiste-frontend:staging
     build:
       context: ./frontend
       dockerfile: Dockerfile

--- a/frontend/nginx/templates/default.conf.template
+++ b/frontend/nginx/templates/default.conf.template
@@ -5,11 +5,13 @@ server {
 
     location / {
       try_files $uri $uri/ /index.html;
-      add_header Cache-Control "no-store, no-cache, must-revalidate";
     }
 
     location /api/ {
         proxy_pass http://${BACKEND_HOST}:${BACKEND_PORT};
         proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
     }
 }


### PR DESCRIPTION
fix for backend error:

ValidationError: The 'Forwarded' header (standardized X-Forwarded-For) is set but currently being ignored. Add a custom keyGenerator to use a value from this header. See https://express-rate-limit.github.io/ERR_ERL_FORWARDED_HEADER/ for more information.
at Object.forwardedHeader (file:///app/node_modules/express-rate-limit/dist/index.mjs:352:13)
at wrappedValidations.<computed> [as forwardedHeader] (file:///app/node_modules/express-rate-limit/dist/index.mjs:651:22)
at Object.keyGenerator (file:///app/node_modules/express-rate-limit/dist/index.mjs:755:20)
at file:///app/node_modules/express-rate-limit/dist/index.mjs:815:32
at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
at async file:///app/node_modules/express-rate-limit/dist/index.mjs:796:5 {
code: 'ERR_ERL_FORWARDED_HEADER',
help: 'https://express-rate-limit.github.io/ERR_ERL_FORWARDED_HEADER/'
}